### PR TITLE
Implement networking sessions base

### DIFF
--- a/TowerDefenseClient/.idea/artifacts/TowerDefenseClient_main_jar.xml
+++ b/TowerDefenseClient/.idea/artifacts/TowerDefenseClient_main_jar.xml
@@ -1,0 +1,17 @@
+<component name="ArtifactManager">
+  <artifact type="jar" build-on-make="true" name="TowerDefenseClient.main:jar">
+    <output-path>$PROJECT_DIR$/out/artifacts/TowerDefenseClient_main_jar</output-path>
+    <root id="archive" name="TowerDefenseClient.main.jar">
+      <element id="directory" name="META-INF">
+        <element id="file-copy" path="$PROJECT_DIR$/src/main/java/META-INF/MANIFEST.MF" />
+      </element>
+      <element id="module-output" name="TowerDefenseClient.main" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.25/da76ca59f6a57ee3102f8f9bd9cee742973efa8a/slf4j-api-1.7.25.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.fasterxml.jackson.core/jackson-core/2.10.0/4e2c5fa04648ec9772c63e2101c53af6504e624e/jackson-core-2.10.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.java-websocket/Java-WebSocket/1.5.1/382b302303c830a7edb20c9ed61c4ac2cdf7a7a4/Java-WebSocket-1.5.1.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-simple/1.7.9/f918aa891c5402deb6b4dc82862699bb82602a2e/slf4j-simple-1.7.9.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.fasterxml.jackson.core/jackson-annotations/2.10.0/e01cfd93b80d6773b3f757c78e756c9755b47b81/jackson-annotations-2.10.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.fasterxml.jackson.core/jackson-databind/2.10.0/1127c9cf62f2bb3121a3a2a0a1351d251a602117/jackson-databind-2.10.0.jar" path-in-jar="/" />
+    </root>
+  </artifact>
+</component>

--- a/TowerDefenseClient/.idea/vcs.xml
+++ b/TowerDefenseClient/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/TowerDefenseClient/build.gradle
+++ b/TowerDefenseClient/build.gradle
@@ -15,6 +15,8 @@ dependencies {
 
     implementation 'org.java-websocket:Java-WebSocket:1.5.1'
     implementation 'org.slf4j:slf4j-simple:1.7.9'
+
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
 }
 
 test {

--- a/TowerDefenseClient/src/main/java/Client.java
+++ b/TowerDefenseClient/src/main/java/Client.java
@@ -1,55 +1,23 @@
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 
-import org.java_websocket.client.WebSocketClient;
-import org.java_websocket.drafts.Draft;
-import org.java_websocket.drafts.Draft_6455;
-import org.java_websocket.handshake.ServerHandshake;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import game.Troop;
+import net.Session;
 
-public class Client extends WebSocketClient {
+public class Client {
+    public static void main(String[] args) throws InterruptedException, URISyntaxException, JsonProcessingException {
+        Troop troop = new Troop();
+        Session.getInstance().register(troop);
+        troop.send();
+        troop.setX(5);
+        troop.send();
 
-    public Client(URI serverUri, Draft draft) {
-        super(serverUri, draft);
-    }
+        Thread.sleep(10000);
 
-    public Client(URI serverURI) {
-        super(serverURI);
-    }
-
-    @Override
-    public void onOpen(ServerHandshake handshakedata) {
-//        send("Hello, it is me. Mario :)");
-        System.out.println("new connection opened");
-    }
-
-    @Override
-    public void onClose(int code, String reason, boolean remote) {
-        System.out.println("closed with exit code " + code + " additional info: " + reason);
-    }
-
-    @Override
-    public void onMessage(String message) {
-        System.out.println("received message: " + message);
-    }
-
-    @Override
-    public void onMessage(ByteBuffer message) {
-        System.out.println("received ByteBuffer");
-    }
-
-    @Override
-    public void onError(Exception ex) {
-        System.err.println("an error occurred:" + ex);
-    }
-
-    public static void main(String[] args) throws URISyntaxException, InterruptedException {
-        WebSocketClient client = new Client(new URI("ws://localhost:8887"));
-        client.connectBlocking();
-        client.send("Hello Better");
-
-        WebSocketClient client2 = new Client(new URI("ws://localhost:8887"));
-        client2.connectBlocking();
-        client2.send("Hello John");
+        Troop troop2 = new Troop();
+        Session.getInstance().register(troop2);
+        troop2.send();
+        troop2.setX(3);
+        troop2.send();
     }
 }

--- a/TowerDefenseClient/src/main/java/META-INF/MANIFEST.MF
+++ b/TowerDefenseClient/src/main/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: Client
+

--- a/TowerDefenseClient/src/main/java/game/Troop.java
+++ b/TowerDefenseClient/src/main/java/game/Troop.java
@@ -1,0 +1,41 @@
+package game;
+
+import java.util.UUID;
+
+import net.Serverside;
+
+public class Troop extends Serverside {
+    private float x;
+    private float y;
+
+    public Troop() {
+        super();
+    }
+
+    public Troop(UUID uuid) {
+        super(uuid);
+    }
+
+    @Override
+    public String getType() {
+        return "troop"; // Our set type
+    }
+
+    public float getX() {
+        return x;
+    }
+
+    public void setX(float x) {
+        this.x = x;
+        System.out.println(uuid + ": setX: " + x);
+    }
+
+    public float getY() {
+        return y;
+    }
+
+    public void setY(float y) {
+        this.y = y;
+        System.out.println(uuid + ": setY: " + y);
+    }
+}

--- a/TowerDefenseClient/src/main/java/net/Serverside.java
+++ b/TowerDefenseClient/src/main/java/net/Serverside.java
@@ -1,0 +1,57 @@
+package net;
+
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class Serverside {
+    /**
+     * uuid is used to safely identify each Object uniquely.
+     */
+    protected UUID uuid;
+
+    public Serverside() {
+        this(UUID.randomUUID());
+    }
+
+    public Serverside(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    /**
+     * send sends this Object over to the Server.
+     * @throws URISyntaxException
+     * @throws InterruptedException
+     * @throws JsonProcessingException
+     */
+    public void send() throws URISyntaxException, InterruptedException,
+            JsonProcessingException {
+        Session.getInstance().send(new ObjectMapper().writeValueAsString(this));
+    }
+
+    /**
+     * receive parses the message for us and updates this Object.
+     * FIXME: I'm not actually certain whether it updates, needs testing to
+     * confirm.
+     * @param json
+     * @throws JsonProcessingException
+     */
+    public void receive(String json) throws JsonProcessingException {
+        new ObjectMapper().readValue(json, this.getClass());
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    /**
+     * getType retrieves the object type. Needed to identify what kind of object
+     * we are sending to a server (or retrieving in that matter).
+     * @return Object type literal.
+     */
+    abstract public String getType();
+}

--- a/TowerDefenseClient/src/main/java/net/Session.java
+++ b/TowerDefenseClient/src/main/java/net/Session.java
@@ -1,0 +1,122 @@
+package net;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import game.Troop;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+
+/**
+ * Session is a Singleton that is used for communications with the Server.
+ */
+public class Session extends WebSocketClient {
+    /**
+     * instance is a single instance of the Session.
+     */
+    private static Session instance = null;
+
+    /**
+     * objects holds all the objects that are shared with a Server by their
+     * UUID.
+     */
+    private final Map<UUID, Serverside> objects;
+
+    private Session() throws InterruptedException, URISyntaxException {
+        super(new URI("ws://localhost:8887"));
+        objects = new HashMap<>();
+        connectBlocking();
+    }
+
+    public static synchronized Session getInstance() throws URISyntaxException,
+            InterruptedException {
+        if (instance == null)
+            instance = new Session();
+        return instance;
+    }
+
+    /**
+     * register registers a new object about which to listen from the Server.
+     * @param object Object to register.
+     */
+    public void register(Serverside object) throws URISyntaxException,
+            InterruptedException, JsonProcessingException {
+        if (objects.containsKey(object.uuid)) {
+            System.out.println("trying to register existing: " + object.uuid);
+            return;
+        }
+        objects.put(object.uuid, object);
+        System.out.println("register: " + object.uuid);
+    }
+
+    /**
+     * unregister unregisters the object.
+     *
+     * TODO: deletion is lacking ATM. Deleted objects may be deleted locally but
+     * will re-appear the second they are updated by the Server.
+     * @param object Object to unregister.
+     */
+    public void unregister(Serverside object) {
+        objects.remove(object.uuid);
+    }
+
+    @Override
+    public void onOpen(ServerHandshake handshake) {
+        System.out.println("connection opened"); // Good.
+    }
+
+    @Override
+    public void onMessage(String message) {
+        try {
+            // Try extracting UUID from the message.
+            ObjectNode node = new ObjectMapper().readValue(message,
+                    ObjectNode.class);
+            UUID uuid = UUID.fromString(node.get("uuid").asText());
+
+            synchronized (this) {
+                Serverside object = this.objects.get(uuid);
+                if (object == null) {
+                    // New object
+                    // Or a deleted one.. and we are re-creating it..
+                    // TODO: handle deletion
+
+                    // Check for a recognizable type
+                    switch (node.get("type").asText()) {
+                        case "troop":
+                            object = new Troop(uuid);
+                            register(object);
+                            break;
+
+                        default:
+                            System.out.println("unregistered unknown object: " +
+                                    uuid);
+                            return;
+                    }
+                }
+                // Update the object
+                object.receive(message);
+            }
+        } catch (JsonProcessingException | URISyntaxException |
+                InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void onClose(int code, String reason, boolean remote) {
+        System.out.println("connection closed");
+        System.exit(0);
+    }
+
+    @Override
+    public void onError(Exception ex) {
+        System.out.println("an error occurred: " + ex);
+        System.exit(1);
+    }
+}

--- a/TowerDefenseServer/.idea/TowerDefenseServer.iml
+++ b/TowerDefenseServer/.idea/TowerDefenseServer.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="TowerDefenseServer" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="org.example" external.system.module.version="1.0-SNAPSHOT" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/TowerDefenseServer/.idea/modules.xml
+++ b/TowerDefenseServer/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/TowerDefenseServer.iml" filepath="$PROJECT_DIR$/.idea/TowerDefenseServer.iml" />
+    </modules>
+  </component>
+</project>

--- a/TowerDefenseServer/.idea/vcs.xml
+++ b/TowerDefenseServer/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/TowerDefenseServer/src/main/java/net/Session.java
+++ b/TowerDefenseServer/src/main/java/net/Session.java
@@ -1,0 +1,66 @@
+package net;
+
+import org.java_websocket.WebSocket;
+
+/**
+ * Session represents a two player connection session.
+ */
+public class Session {
+    private WebSocket a;
+    private WebSocket b;
+
+    public Session(WebSocket first) {
+        this.a = first;
+        this.b = null;
+    }
+
+    public Session(WebSocket first, WebSocket second) {
+        this.a = first;
+        this.b = second;
+    }
+
+    /**
+     * getOther retrieves other associated connection.
+     * @param socket This connection.
+     * @return Other associated connection.
+     */
+    public WebSocket getOther(WebSocket socket) {
+        if (this.a == socket)
+            return this.b;
+        return this.a;
+    }
+
+    /**
+     * add adds a socket to a Session. If session is full, add is no-op.
+     * @param socket WebSocket to add.
+     */
+    public void add(WebSocket socket) {
+        if (this.a == null) {
+            this.a = socket;
+            return;
+        }
+        if (this.b == null) {
+            this.b = socket;
+            return;
+        }
+        return;
+    }
+
+    /**
+     * @return number of associated connections.
+     */
+    public int count() {
+        int c = 0;
+        if (a != null) c++;
+        if (b != null) c++;
+        return c;
+    }
+
+    /**
+     * close closes associated WebSocket connections.
+     */
+    public void close() {
+        if (this.a != null) this.a.close();
+        if (this.b != null) this.b.close();
+    }
+}


### PR DESCRIPTION
Current implementation is basically `peer-to-peer` with the server being
a middleman (or data router, whatever you may call it).

## Clients

Abstract `Serverside` class is somewhat of a plug-and-play
(not really). But close enough. A bit of lackluster implementation, not
sure how it will scale up.  
Maybe renaming `Serverside` to `PeerShared` or something along that
line would describe it better for the time being.

## Server

Multiple session management, each for two players is solid.

## Missing

Object deletion is straight up not supported.